### PR TITLE
Add support for IntelliJ Ultimate Edition

### DIFF
--- a/src/main/scala/Keys.scala
+++ b/src/main/scala/Keys.scala
@@ -20,6 +20,10 @@ object Keys {
     "idea-external-plugins",
     "List of third-party plugins this project depends on")
 
+  lazy val ideaEdition = SettingKey[IdeaEdition](
+    "idea-edition",
+    "Edition of Intellij IDEA to use in project")
+
   lazy val ideaBaseDirectory = TaskKey[File](
     "idea-base-directory",
     "Directory where downloaded IDEA binaries and sources are unpacked")
@@ -55,10 +59,26 @@ object Keys {
     final case class Jar(name: String, url: URL) extends IdeaPlugin
   }
 
+  sealed trait IdeaEdition {
+    val name: String
+  }
+
+  object IdeaEdition {
+    object Community extends IdeaEdition {
+      override val name = "ideaIC"
+    }
+
+    object Ultimate extends IdeaEdition {
+      override val name = "ideaIU"
+    }
+  }
+
   lazy val buildSettings: Seq[Setting[_]] = Seq(
     ideaBuild := "LATEST-EAP-SNAPSHOT",
 
     ideaDownloadDirectory := baseDirectory.value / "idea",
+
+    ideaEdition := IdeaEdition.Community,
 
     ideaBaseDirectory <<= (ideaDownloadDirectory, ideaBuild).map {
       (downloadDir, build) => downloadDir / build
@@ -84,6 +104,6 @@ object Keys {
 
     unmanagedJars in Compile ++= ideaFullJars.value,
 
-    updateIdea <<= (ideaBaseDirectory, ideaBuild, ideaExternalPlugins, streams).map(Tasks.updateIdea)
+    updateIdea <<= (ideaBaseDirectory, ideaEdition, ideaBuild, ideaExternalPlugins, streams).map(Tasks.updateIdea)
   )
 }

--- a/src/main/scala/Tasks.scala
+++ b/src/main/scala/Tasks.scala
@@ -10,14 +10,14 @@ import java.io.IOException
 object Tasks {
   import Keys._
 
-  def updateIdea(baseDir: File, build: String, externalPlugins: Seq[IdeaPlugin], streams: TaskStreams): Unit = {
+  def updateIdea(baseDir: File, edition: IdeaEdition, build: String, externalPlugins: Seq[IdeaPlugin], streams: TaskStreams): Unit = {
     implicit val log = streams.log
 
     if (baseDir.isDirectory) {
       log.info(s"Skip downloading and unpacking IDEA because $baseDir exists")
     } else {
       IO.createDirectory(baseDir)
-      downloadIdeaAndSources(baseDir, build)
+      downloadIdeaAndSources(baseDir, edition, build)
     }
 
     val externalPluginsDir = baseDir / "externalPlugins"
@@ -33,11 +33,11 @@ object Tasks {
     (pluginsDirs * (globFilter("*.jar") -- "asm*.jar")).classpath
   }
 
-  private def downloadIdeaAndSources(baseDir: File, build: String)(implicit log: Logger): Unit = {
+  private def downloadIdeaAndSources(baseDir: File, edition: IdeaEdition, build: String)(implicit log: Logger): Unit = {
     val repositoryUrl = getRepositoryForBuild(build)
 
-    val ideaUrl = url(s"$repositoryUrl/ideaIC/$build/ideaIC-$build.zip")
-    val ideaZipFile = baseDir.getParentFile / s"ideaIC-$build.zip"
+    val ideaUrl = url(s"$repositoryUrl/${edition.name}/$build/${edition.name}-$build.zip")
+    val ideaZipFile = baseDir.getParentFile / s"${edition.name}-$build.zip"
     downloadOrFail(ideaUrl, ideaZipFile)
     unpack(ideaZipFile, baseDir)
 

--- a/src/sbt-test/sbt-idea-plugin/simple-ideaIU-15.0.1/build.sbt
+++ b/src/sbt-test/sbt-idea-plugin/simple-ideaIU-15.0.1/build.sbt
@@ -1,0 +1,5 @@
+lazy val root = project.in(file(".")).enablePlugins(SbtIdeaPlugin)
+
+ideaBuild in ThisBuild := "15.0.1"
+
+ideaEdition in ThisBuild := IdeaEdition.Ultimate

--- a/src/sbt-test/sbt-idea-plugin/simple-ideaIU-15.0.1/project/plugins.sbt
+++ b/src/sbt-test/sbt-idea-plugin/simple-ideaIU-15.0.1/project/plugins.sbt
@@ -1,0 +1,8 @@
+{
+  val pluginVersion = System.getProperty("plugin.version")
+  if(pluginVersion == null)
+    throw new RuntimeException("""|The system property 'plugin.version' is not defined.
+                                  |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else
+    addSbtPlugin("com.dancingrobot84" % "sbt-idea-plugin" % pluginVersion)
+}

--- a/src/sbt-test/sbt-idea-plugin/simple-ideaIU-15.0.1/test
+++ b/src/sbt-test/sbt-idea-plugin/simple-ideaIU-15.0.1/test
@@ -1,0 +1,8 @@
+# check if everything is downloaded
+> updateIdea
+$ exists idea
+$ exists idea/ideaIU-15.0.1.zip
+$ exists idea/15.0.1
+$ exists idea/15.0.1/lib
+$ exists idea/15.0.1/plugins
+$ exists idea/15.0.1/sources.zip


### PR DESCRIPTION
Hi,
Really great plugin. I use it to develop IntelliJ plugin that depends on commercial modules. There is no way to download ultimate edition sdk using your plugin without wrapping `updateIdea` task. The PR fixes this issue.
